### PR TITLE
fix: add dj_static to the list of requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,3 +7,4 @@ django-debug-toolbar==1.2.2
 sh==1.11
 pytz==2014.10
 dj_database_url==0.3.0
+dj_static


### PR DESCRIPTION
Fixes the following error:
File "poireau/common/wsgi.py", line 14, in <module>
    from dj_static import Cling
ImportError: No module named 'dj_static'
